### PR TITLE
Change copyright year in About screen

### DIFF
--- a/app/navigation/SettingsNavigation/SettingsNavigation.tsx
+++ b/app/navigation/SettingsNavigation/SettingsNavigation.tsx
@@ -172,7 +172,7 @@ function About({ navigation }: AboutProps): React.ReactElement {
           </Text>.
         </Text>
         <Text style={styles.paragraphCenter}>
-          Copyright 2021-2022 Massachusetts Institute of Technology
+          Copyright 2021-2025 Massachusetts Institute of Technology
         </Text>
         <TouchableOpacity onPress={goToDeveloperScreen}>
           <Text style={styles.paragraphCenter}>


### PR DESCRIPTION
Updated copyright date from 2021-2022 to 2021-2025 on "about" page #760