### PR TITLE
768: Some Credly Badges Fail Verify

### DIFF
--- a/app/lib/import.ts
+++ b/app/lib/import.ts
@@ -63,7 +63,8 @@ export async function readFile(uri: string): Promise<string> {
 
     if (isPngFile(base64Data)) {
       // Decode base64 to UTF-8 string for embedded JSON extraction
-      const decodedString = base64.decode(base64Data);
+      const arrayBuffer = base64ToArrayBuffer(base64Data);
+      const decodedString = new TextDecoder('utf-8').decode(arrayBuffer);
 
       // Search for the OpenBadge JSON inside PNG
       const keyword = 'openbadgecredential';


### PR DESCRIPTION
Created PR for #768 
Refactor base64 decoding in readFile function to use TextDecoder for improved UTF-8 string extraction from PNG files
**Before Update:**
<img width="747" height="1014" alt="Screenshot 2025-09-15 at 5 31 16 PM" src="https://github.com/user-attachments/assets/64a2334c-336b-47ab-be15-d5e8a55b951a" />
**After Update:**
<img width="747" height="1014" alt="Screenshot 2025-09-15 at 5 30 28 PM" src="https://github.com/user-attachments/assets/0fd8102a-2688-47f0-ae4e-0924c323b636" />
