### PR TITLE
Update blurbs about public link expiration

### DIFF
--- a/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
+++ b/app/screens/PublicLinkScreen/PublicLinkScreen.tsx
@@ -357,7 +357,7 @@ export default function PublicLinkScreen({
           <Text style={mixins.modalBodyText}>
             Creating a public link will allow anyone with the link to view the
             credential. The link will automatically expire 1 year after
-            creation.
+            creation. A public link expiration date is not the same as the expiration date for your credential.
           </Text>
           <Button
             buttonStyle={mixins.buttonClear}

--- a/app/screens/ShareHomeScreen/ShareHomeScreen.tsx
+++ b/app/screens/ShareHomeScreen/ShareHomeScreen.tsx
@@ -153,7 +153,7 @@ export default function ShareHomeScreen({ navigation, route }: ShareHomeScreenPr
         confirmText: 'Create Link',
         body: (
           <>
-            <Text style={mixins.modalBodyText}>Creating a public link will allow anyone with the link to view the credential. The link will automatically expire 1 year after creation.</Text>
+            <Text style={mixins.modalBodyText}>Creating a public link will allow anyone with the link to view the credential. The link will automatically expire 1 year after creation. A public link expiration date is not the same as the expiration date for your credential.</Text>
             <Button
               buttonStyle={mixins.buttonClear}
               titleStyle={[mixins.buttonClearTitle, mixins.modalLinkText]}


### PR DESCRIPTION
Addresses part of https://github.com/openwallet-foundation-labs/learner-credential-wallet/issues/446. New information here included right above link to the lcw.app FAQ site highlighting more information about public links. PR for the LCW website update is here: https://github.com/digitalcredentials/learner-credential-wallet-site/pull/20