### PR TITLE
836: Wallet restore creates duplicate profiles & app allows duplicate…

### DIFF
--- a/app/components/ProfileItem/ProfileItem.tsx
+++ b/app/components/ProfileItem/ProfileItem.tsx
@@ -12,6 +12,7 @@ import { deleteProfile, updateProfile } from '../../store/slices/profile';
 import { exportProfile } from '../../lib/export';
 import { errorMessageFrom } from '../../lib/error';
 import { fmtCredentialCount } from '../../lib/text';
+import { getCredentialName } from '../../lib/credentialName';
 
 enum ActiveModal {
   Rename,
@@ -148,7 +149,7 @@ function DeleteModal({ rawProfileRecord, onRequestClose }: ActionModalProps): Re
             header: 'Delete Profile Details',
             details: {
               [`${rawProfileRecord.rawCredentialRecords.length} total credential`]:
-              rawProfileRecord.rawCredentialRecords.map(({ credential }) => credential.credentialSubject.hasCredential?.name ?? ''),
+              rawProfileRecord.rawCredentialRecords.map(({ credential }) => getCredentialName(credential)),
             },
           },
         },

--- a/app/lib/credentialDisplay/openBadgeCredential.tsx
+++ b/app/lib/credentialDisplay/openBadgeCredential.tsx
@@ -24,6 +24,7 @@ import {
 } from './shared';
 
 import { DATE_FORMAT } from '../../../app.config';
+import { getCredentialName } from '../credentialName';
 
 const getSafeImageSource = (imageUri?: string | null): ImageSourcePropType => {
   return imageUri && imageUri.trim() !== '' ? { uri: imageUri } : defaultIssuerImage;
@@ -57,9 +58,7 @@ const OpenBadgeCredentialCard = ({ rawCredentialRecord }: CredentialCardProps): 
   } = credentialSubjectRenderInfoFrom(credentialSubject);
 
   const issuedToName: string = issuedTo || (name as string);
-  const credentialName = Array.isArray(credentialSubject.achievement)
-    ? credentialSubject.achievement.at(0)?.name ?? null
-    : credentialSubject.achievement?.name ?? null;
+  const credentialName = getCredentialName(credential);
 
   const {
     issuerName,

--- a/app/lib/credentialName.ts
+++ b/app/lib/credentialName.ts
@@ -1,0 +1,16 @@
+import { Credential } from '../types/credential';
+
+/**
+ * Extracts the credential name from a verifiable credential
+ * @param credential The verifiable credential object
+ * @returns The credential name or 'Unknown Credential' if not found
+ */
+export function getCredentialName(credential: Credential): string {
+  let achievement = credential.credentialSubject.hasCredential ?? credential.credentialSubject.achievement;
+  
+  if (Array.isArray(achievement)) {
+    achievement = achievement[0];
+  }
+  
+  return achievement?.name ?? 'Unknown Credential';
+}

--- a/app/lib/parseWallet.ts
+++ b/app/lib/parseWallet.ts
@@ -4,7 +4,9 @@ import { DidDocument, DidKey } from '../types/did';
 import { ProfileMetadata } from '../types/profile';
 
 function isCredential(item: WalletContent): item is Credential {
-  return (item as Credential)['@context']?.includes('https://www.w3.org/2018/credentials/v1') ;
+  const context = (item as Credential)['@context'];
+  return context?.includes('https://www.w3.org/2018/credentials/v1') || 
+         context?.includes('https://www.w3.org/ns/credentials/v2');
 }
 
 function isDidDocument(item: WalletContent): item is DidDocument {

--- a/app/model/profile.ts
+++ b/app/model/profile.ts
@@ -25,6 +25,11 @@ function generateProfileObjectIdHex(): string {
 const UNTITLED_PROFILE_NAME = 'Untitled Profile';
 export const INITIAL_PROFILE_NAME = 'Default';
 
+const WALLET_CONTEXTS = ['https://www.w3.org/2018/credentials/v1', 'https://w3id.org/wallet/v1'] as const;
+function generateWalletUrnId(): string {
+  return `urn:uuid:${uuid.v4()}`;
+}
+
 // Helper function to check if profile names are case-insensitively equal
 function isProfileNameDuplicate(existingName: string, newName: string): boolean {
   return existingName.toLowerCase() === newName.toLowerCase();
@@ -185,8 +190,8 @@ export class ProfileRecord extends Realm.Object implements ProfileRecordRaw {
     ];
 
     const profile: UnlockedWallet = {
-      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://w3id.org/wallet/v1'],
-      id: 'http://example.gov/wallet/3732',
+      '@context': WALLET_CONTEXTS as unknown as string[],
+      id: generateWalletUrnId(),
       type: 'UniversalWallet2020',
       status: 'UNLOCKED',
       contents,

--- a/app/model/profile.ts
+++ b/app/model/profile.ts
@@ -5,6 +5,7 @@ import uuid from 'react-native-uuid';
 import { db } from './DatabaseAccess';
 
 import { mintDid } from '../lib/did';
+import { getCredentialName } from '../lib/credentialName';
 import { UnlockedWallet } from '../types/wallet';
 import { ProfileImportReport, ProfileMetadata } from '../types/profile';
 import { parseWalletContents } from '../lib/parseWallet';
@@ -227,11 +228,7 @@ export class ProfileRecord extends Realm.Object implements ProfileRecordRaw {
 
         await Promise.all(
           credentials.map(async (credential) => {
-            let achievement = credential.credentialSubject.hasCredential ?? credential.credentialSubject.achievement;
-            if (Array.isArray(achievement)) {
-              achievement = achievement[0];
-            }
-            const credentialName = achievement?.name ?? 'Unknown Credential';
+            const credentialName = getCredentialName(credential);
             if (profileCredentialIds.includes(credential.id)) {
               profileImportReport.credentials.duplicate.push(credentialName);
               return;
@@ -258,11 +255,7 @@ export class ProfileRecord extends Realm.Object implements ProfileRecordRaw {
 
       await Promise.all(
         credentials.map(async (credential) => {
-          let achievement = credential.credentialSubject.hasCredential ?? credential.credentialSubject.achievement;
-          if (Array.isArray(achievement)) {
-            achievement = achievement[0];
-          }
-          const credentialName = achievement?.name ?? 'Unknown Credential';
+          const credentialName = getCredentialName(credential);
 
           try {
             await CredentialRecord.addCredentialRecord({ credential, profileRecordId });

--- a/app/screens/HomeScreen/HomeScreen.tsx
+++ b/app/screens/HomeScreen/HomeScreen.tsx
@@ -13,6 +13,7 @@ import { HomeScreenProps, RenderItemProps } from './HomeScreen.d';
 import { CredentialRecordRaw } from '../../model';
 import { useAppDispatch, useDynamicStyles, useShareCredentials } from '../../hooks';
 import { deleteCredential, selectRawCredentialRecords } from '../../store/slices/credential';
+import { getCredentialName } from '../../lib/credentialName';
 
 
 export default function HomeScreen({ navigation }: HomeScreenProps): React.ReactElement {
@@ -23,7 +24,7 @@ export default function HomeScreen({ navigation }: HomeScreenProps): React.React
   const dispatch = useAppDispatch();
   const share = useShareCredentials();
 
-  const itemToDeleteName = itemToDelete?.credential.credentialSubject.hasCredential?.name ?? '';
+  const itemToDeleteName = itemToDelete ? getCredentialName(itemToDelete.credential) : '';
 
   function renderItem({ item }: RenderItemProps) {
     const { credential } = item;

--- a/app/screens/ManageProfilesScreen/ManageProfilesScreen.styles.tsx
+++ b/app/screens/ManageProfilesScreen/ManageProfilesScreen.styles.tsx
@@ -15,4 +15,9 @@ export default createDynamicStyleSheet(({ theme, mixins }) => ({
     ...mixins.input,
     backgroundColor: theme.color.foregroundPrimary,
   },
+  errorText: {
+    marginTop: 8,
+    fontSize: 14,
+    textAlign: 'center',
+  },
 }));

--- a/app/types/profile.ts
+++ b/app/types/profile.ts
@@ -2,6 +2,7 @@ import { CredentialImportReport } from './credential';
 
 export type ProfileImportReport = {
   userIdImported: boolean;
+  profileDuplicate?: boolean;
   credentials: CredentialImportReport;
 };
 

--- a/test/credentialName.test.ts
+++ b/test/credentialName.test.ts
@@ -1,0 +1,80 @@
+import { getCredentialName } from '../app/lib/credentialName';
+import { Credential } from '../app/types/credential';
+
+describe('getCredentialName', () => {
+  it('should return credential name from hasCredential property', () => {
+    const credential: Partial<Credential> = {
+      credentialSubject: {
+        hasCredential: {
+          name: 'Bachelor of Science in Computer Science'
+        }
+      }
+    };
+
+    const result = getCredentialName(credential as Credential);
+    expect(result).toBe('Bachelor of Science in Computer Science');
+  });
+
+  it('should return credential name from achievement property', () => {
+    const credential: Partial<Credential> = {
+      credentialSubject: {
+        achievement: {
+          name: 'Digital Marketing Certificate'
+        }
+      }
+    };
+
+    const result = getCredentialName(credential as Credential);
+    expect(result).toBe('Digital Marketing Certificate');
+  });
+
+  it('should return credential name from first element when achievement is array', () => {
+    const credential: Partial<Credential> = {
+      credentialSubject: {
+        achievement: [
+          { name: 'First Achievement' },
+          { name: 'Second Achievement' }
+        ]
+      }
+    };
+
+    const result = getCredentialName(credential as Credential);
+    expect(result).toBe('First Achievement');
+  });
+
+  it('should prioritize hasCredential over achievement', () => {
+    const credential: Partial<Credential> = {
+      credentialSubject: {
+        hasCredential: {
+          name: 'Has Credential Name'
+        },
+        achievement: {
+          name: 'Achievement Name'
+        }
+      }
+    };
+
+    const result = getCredentialName(credential as Credential);
+    expect(result).toBe('Has Credential Name');
+  });
+
+  it('should return "Unknown Credential" when no name is found', () => {
+    const credential: Partial<Credential> = {
+      credentialSubject: {}
+    };
+
+    const result = getCredentialName(credential as Credential);
+    expect(result).toBe('Unknown Credential');
+  });
+
+  it('should return "Unknown Credential" when achievement has no name', () => {
+    const credential: Partial<Credential> = {
+      credentialSubject: {
+        achievement: {}
+      }
+    };
+
+    const result = getCredentialName(credential as Credential);
+    expect(result).toBe('Unknown Credential');
+  });
+});

--- a/test/profileDuplicates.test.ts
+++ b/test/profileDuplicates.test.ts
@@ -1,0 +1,136 @@
+import { ProfileRecord } from '../app/model/profile';
+import { HumanReadableError } from '../app/lib/error';
+
+// Mock the database and dependencies
+jest.mock('../app/model/DatabaseAccess');
+jest.mock('../app/lib/did');
+jest.mock('../app/model/did');
+jest.mock('../app/lib/parseWallet');
+
+describe('Profile Duplicate Prevention', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('addProfileRecord', () => {
+    it('should throw error when profile name already exists', async () => {
+      // Mock existing profiles
+      const mockExistingProfiles = [
+        { profileName: 'Test Profile', _id: 'id1' },
+        { profileName: 'Another Profile', _id: 'id2' }
+      ];
+      
+      jest.spyOn(ProfileRecord, 'getAllProfileRecords').mockResolvedValue(mockExistingProfiles as any);
+
+      await expect(
+        ProfileRecord.addProfileRecord({ profileName: 'Test Profile' })
+      ).rejects.toThrow(HumanReadableError);
+      
+      await expect(
+        ProfileRecord.addProfileRecord({ profileName: 'Test Profile' })
+      ).rejects.toThrow('A profile with the name "Test Profile" already exists');
+    });
+
+    it('should throw error when profile name already exists with different case', async () => {
+      // Mock existing profiles
+      const mockExistingProfiles = [
+        { profileName: 'Test Profile', _id: 'id1' },
+        { profileName: 'Another Profile', _id: 'id2' }
+      ];
+      
+      jest.spyOn(ProfileRecord, 'getAllProfileRecords').mockResolvedValue(mockExistingProfiles as any);
+
+      // Test various case combinations
+      await expect(
+        ProfileRecord.addProfileRecord({ profileName: 'test profile' })
+      ).rejects.toThrow(HumanReadableError);
+      
+      await expect(
+        ProfileRecord.addProfileRecord({ profileName: 'TEST PROFILE' })
+      ).rejects.toThrow(HumanReadableError);
+      
+      await expect(
+        ProfileRecord.addProfileRecord({ profileName: 'TeSt PrOfIlE' })
+      ).rejects.toThrow(HumanReadableError);
+      
+      await expect(
+        ProfileRecord.addProfileRecord({ profileName: 'test profile' })
+      ).rejects.toThrow('A profile with the name "test profile" already exists');
+    });
+
+    it('should allow creating profile with unique name', async () => {
+      const mockExistingProfiles = [
+        { profileName: 'Existing Profile', _id: 'id1' }
+      ];
+      
+      jest.spyOn(ProfileRecord, 'getAllProfileRecords').mockResolvedValue(mockExistingProfiles as any);
+      
+      // Mock the database write operation
+      const mockRawProfile = { profileName: 'New Profile', _id: 'newId' };
+      jest.spyOn(ProfileRecord, 'rawFrom').mockReturnValue(mockRawProfile as any);
+      
+      // This should not throw
+      expect(async () => {
+        await ProfileRecord.addProfileRecord({ profileName: 'New Profile' });
+      }).not.toThrow();
+    });
+  });
+
+  describe('importProfileRecord', () => {
+    it('should skip profile creation when profile name already exists', async () => {
+      const mockExistingProfiles = [
+        { profileName: 'Existing Profile', _id: 'existingId' }
+      ];
+      
+      jest.spyOn(ProfileRecord, 'getAllProfileRecords').mockResolvedValue(mockExistingProfiles as any);
+      
+      // Mock parseWalletContents to return the required wallet contents
+      const { parseWalletContents } = require('../app/lib/parseWallet');
+      parseWalletContents.mockReturnValue({
+        credentials: [],
+        didDocument: { id: 'did:example:123' },
+        verificationKey: { type: 'Ed25519VerificationKey2020' },
+        keyAgreementKey: { type: 'X25519KeyAgreementKey2020' },
+        profileMetadata: {
+          data: { profileName: 'Existing Profile' }
+        }
+      });
+      
+      const mockWalletData = '{}'; // The actual content doesn't matter since we're mocking parseWalletContents
+      
+      // The import should mark profile as duplicate
+      const result = await ProfileRecord.importProfileRecord(mockWalletData);
+      
+      expect(result.userIdImported).toBe(false);
+      expect(result.profileDuplicate).toBe(true);
+    });
+
+    it('should skip profile creation when profile name already exists with different case', async () => {
+      const mockExistingProfiles = [
+        { profileName: 'Existing Profile', _id: 'existingId' }
+      ];
+      
+      jest.spyOn(ProfileRecord, 'getAllProfileRecords').mockResolvedValue(mockExistingProfiles as any);
+      
+      // Mock parseWalletContents to return the required wallet contents
+      const { parseWalletContents } = require('../app/lib/parseWallet');
+      parseWalletContents.mockReturnValue({
+        credentials: [],
+        didDocument: { id: 'did:example:123' },
+        verificationKey: { type: 'Ed25519VerificationKey2020' },
+        keyAgreementKey: { type: 'X25519KeyAgreementKey2020' },
+        profileMetadata: {
+          data: { profileName: 'existing profile' }
+        }
+      });
+      
+      const mockWalletData = '{}'; // The actual content doesn't matter since we're mocking parseWalletContents
+      
+      // The import should mark profile as duplicate even with different case
+      const result = await ProfileRecord.importProfileRecord(mockWalletData);
+      
+      expect(result.userIdImported).toBe(false);
+      expect(result.profileDuplicate).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Created PR for #836 

- Wallet restore should skip both duplicate credentials and duplicate profiles.
- Users should not be able to create profiles with the same name as an existing profile in the app.