### PR TITLE
Coverage command fix

### DIFF
--- a/jest.config.coverage.ts
+++ b/jest.config.coverage.ts
@@ -5,10 +5,19 @@ const packagesToTransformWithBabel = [
   'react-native',
   'expo-secure-store',
   'expo-modules-core',
+  'expo-font',
   'react-native-fs',
   '@digitalcredentials/http-client',
   'realm',
   '@realm', // <-- critical for @realm/fetch
+  'react-redux',
+  '@reduxjs/toolkit',
+  '@testing-library/react-native',
+  '@expo/vector-icons',
+  'immer',
+  'react-native-securerandom',
+  'rn-animated-ellipsis',
+  'react-native-outside-press'
 ];
 
 const transformIgnorePatterns = [


### PR DESCRIPTION
Created PR for #854 

The issue was that the coverage Jest configuration had an incomplete list of packages to transform with Babel. When running npm test, it uses jest.config.ts which includes all necessary packages for transformation. However, when running npm run coverage, it uses jest.config.coverage.ts which was missing several packages, causing transformation issues and test failures which has been updated.