### PR TITLE
866: Duplicate profile names allowed when renaming existing profile

### DIFF
--- a/app/components/ConfirmModal/ConfirmModal.tsx
+++ b/app/components/ConfirmModal/ConfirmModal.tsx
@@ -101,10 +101,7 @@ export default function ConfirmModal({
                 disabled={confirmButtonDisabled}
                 disabledStyle={mixins.buttonDisabled}
                 disabledTitleStyle={mixins.buttonTitle}
-                onPress={() => {
-                  onRequestClose();
-                  onConfirm();
-                }}
+                onPress={onConfirm}
               />
             ) : null}
           </View>

--- a/app/components/ProfileItem/ProfileItem.tsx
+++ b/app/components/ProfileItem/ProfileItem.tsx
@@ -77,11 +77,18 @@ export default function ProfileItem({ rawProfileRecord }: ProfileItemProps): Rea
 function RenameModal({ rawProfileRecord, onRequestClose }: ActionModalProps): React.ReactElement {
   const { styles, theme } = useDynamicStyles(dynamicStyleSheet);
   const [newName, setNewName] = useState(rawProfileRecord.profileName);
+  const [errorMessage, setErrorMessage] = useState('');
   const dispatch = useAppDispatch();
 
   async function onSave() {
-    await dispatch(updateProfile({ ...rawProfileRecord, profileName: newName }));
-    onRequestClose();
+    if (!newName) return;
+    try {
+      await dispatch(updateProfile({ ...rawProfileRecord, profileName: newName })).unwrap();
+      setErrorMessage('');
+      onRequestClose();
+    } catch (err: any) {
+      setErrorMessage(err?.message || 'Failed to rename profile');
+    }
   }
 
   return (
@@ -94,7 +101,10 @@ function RenameModal({ rawProfileRecord, onRequestClose }: ActionModalProps): Re
     >
       <TextInput
         value={newName}
-        onChangeText={setNewName}
+        onChangeText={(text) => {
+          setNewName(text);
+          setErrorMessage('');
+        }}
         style={styles.input}
         outlineColor={theme.color.textPrimary}
         selectionColor={theme.color.textPrimary}
@@ -111,6 +121,11 @@ function RenameModal({ rawProfileRecord, onRequestClose }: ActionModalProps): Re
         onTextInput={() => {}}
         tvParallaxProperties={undefined}
       />
+      {errorMessage ? (
+        <Text style={{ color: theme.color.error }}>
+          {errorMessage}
+        </Text>
+      ) : null}
     </ConfirmModal>
   );
 }


### PR DESCRIPTION
Created PR for #866 
When renaming a profile, the system validates the new name to ensure it does not duplicate any existing profile’s name 
The app displays an appropriate error or warning message if a duplicate name is entered

<img width="1269" height="1020" alt="Screenshot 2025-10-08 at 12 44 03 PM" src="https://github.com/user-attachments/assets/783acd04-5fdd-4ca9-b628-94b36582a9d6" />
